### PR TITLE
Change apidifftira response

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,37 +189,38 @@ Some example responses from calls to the ApiDiff service with specifications fro
   **Response**:
   
   ```
-  {
-      "newGlobalTiraAnnotation": {
-          "utilizer_category": [
-              {
-                  "name": "Health Insurance Company"
-              }
-          ]
-      },
-      "missingGlobalTiraAnnotation": {
-          "profiling": {
-              "reason": "Health profile based on series of health related behaviour."
-          }
-      },
-      "changedGlobalTiraAnnotation": {
-          "oldGlobalTiraAnnotation": {
-              "utilizer": [
+    {
+      "newGlobalTiraAnnotation": [
+          {
+              "utilizer_category": [
                   {
-                      "name": "AWS",
-                      "non_eu_country": true,
-                      "country": "UK"
+                      "name": "Health Insurance Company"
                   }
               ]
-          },
-          "newGlobalTiraAnnotation": [
-              {
+          }
+      ],
+      "missingGlobalTiraAnnotation": [
+          {
+              "profiling": {
+                  "reason": "Health profile based on series of health related behaviour."
+              }
+          }
+      ],
+      "changedGlobalTiraAnnotation": [
+          {
+              "key": "utilizer",
+              "oldGlobalTiraAnnotation": {
+                  "name": "AWS",
+                  "non_eu_country": true,
+                  "country": "UK"
+              },
+              "newGlobalTiraAnnotation": {
                   "name": "AWS2",
                   "non_eu_country": true,
                   "country": "UK"
               }
-          ]
-      },
+          }
+      ],
       "newSchemaTiraAnnotations": [
           {
               "schemaName": "JumpEvent",
@@ -281,21 +282,21 @@ Some example responses from calls to the ApiDiff service with specifications fro
       ],
       "changedSchemaTiraAnnotations": [
           {
-              "schemaName": "SameEvent",
-              "oldSchemaTiraAnnotation": {
-                  "retention-time": {
-                      "volatile": true
-                  },
-                  "special_category": {
-                      "category": "Health Data"
-                  }
-              },
-              "newSchemaTiraAnnotation": {
-                  "retention-time": {
-                      "volatile": true
-                  }
-              }
-          }
-      ]
+            "schemaName": "SameEvent",
+            "oldSchemaTiraAnnotation": {
+                "retention-time": {
+                    "volatile": true
+                },
+                "special_category": {
+                    "category": "Health Data"
+                }
+            },
+            "newSchemaTiraAnnotation": {
+                "retention-time": {
+                    "volatile": true
+                }
+            }
+        }
+    ]
   }
   ```

--- a/src/main/java/com/teamgreen/apidiff/model/ApiDiff.java
+++ b/src/main/java/com/teamgreen/apidiff/model/ApiDiff.java
@@ -3,15 +3,16 @@ package com.teamgreen.apidiff.model;
 import lombok.Data;
 
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
 public class ApiDiff {
     private boolean generalDifferenceGiven;
     private boolean potentiallyPrivacyRelatedDifferencesGiven;
-    private List<NewEndpoint> newEndpoints;
-    private List<MissingEndpoint> missingEndpoints;
-    private List<ChangedOperation> changedOperations;
+    private List<NewEndpoint> newEndpoints = new ArrayList<>();
+    private List<MissingEndpoint> missingEndpoints = new ArrayList<>();
+    private List<ChangedOperation> changedOperations = new ArrayList<>();
 
     public ApiDiff() {
         this.generalDifferenceGiven = false;

--- a/src/main/java/com/teamgreen/apidiff/model/ApiDiffTira.java
+++ b/src/main/java/com/teamgreen/apidiff/model/ApiDiffTira.java
@@ -12,9 +12,9 @@ public class ApiDiffTira {
     private List<JsonNode> missingGlobalTiraAnnotation = new ArrayList<>();
     private List<ChangedGlobalTiraAnnotation> changedGlobalTiraAnnotation = new ArrayList<>();
 
-    private List<SchemaTiraAnnotation> newSchemaTiraAnnotations;
-    private List<SchemaTiraAnnotation> missingSchemaTiraAnnotations;
-    private List<ChangedSchemaTiraAnnotation> changedSchemaTiraAnnotations;
+    private List<SchemaTiraAnnotation> newSchemaTiraAnnotations = new ArrayList<>();
+    private List<SchemaTiraAnnotation> missingSchemaTiraAnnotations = new ArrayList<>();
+    private List<ChangedSchemaTiraAnnotation> changedSchemaTiraAnnotations = new ArrayList<>();
 
 
 }

--- a/src/main/java/com/teamgreen/apidiff/model/ApiDiffTira.java
+++ b/src/main/java/com/teamgreen/apidiff/model/ApiDiffTira.java
@@ -3,15 +3,18 @@ package com.teamgreen.apidiff.model;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
 public class ApiDiffTira {
-    private JsonNode newGlobalTiraAnnotation;
-    private JsonNode missingGlobalTiraAnnotation;
-    private ChangedGlobalTiraAnnotation changedGlobalTiraAnnotation;
+    private List<JsonNode> newGlobalTiraAnnotation = new ArrayList<>();
+    private List<JsonNode> missingGlobalTiraAnnotation = new ArrayList<>();
+    private List<ChangedGlobalTiraAnnotation> changedGlobalTiraAnnotation = new ArrayList<>();
 
     private List<SchemaTiraAnnotation> newSchemaTiraAnnotations;
     private List<SchemaTiraAnnotation> missingSchemaTiraAnnotations;
     private List<ChangedSchemaTiraAnnotation> changedSchemaTiraAnnotations;
+
+
 }

--- a/src/main/java/com/teamgreen/apidiff/model/ChangedGlobalTiraAnnotation.java
+++ b/src/main/java/com/teamgreen/apidiff/model/ChangedGlobalTiraAnnotation.java
@@ -5,10 +5,12 @@ import lombok.Data;
 
 @Data
 public class ChangedGlobalTiraAnnotation {
+    private String key;
     private JsonNode oldGlobalTiraAnnotation;
     private JsonNode newGlobalTiraAnnotation;
 
-    public ChangedGlobalTiraAnnotation(JsonNode oldGlobalTiraAnnotation, JsonNode newGlobalTiraAnnotation) {
+    public ChangedGlobalTiraAnnotation(String key, JsonNode oldGlobalTiraAnnotation, JsonNode newGlobalTiraAnnotation) {
+        this.key = key;
         this.oldGlobalTiraAnnotation = oldGlobalTiraAnnotation;
         this.newGlobalTiraAnnotation = newGlobalTiraAnnotation;
     }

--- a/src/main/java/com/teamgreen/apidiff/model/GlobalTiraAnnotation.java
+++ b/src/main/java/com/teamgreen/apidiff/model/GlobalTiraAnnotation.java
@@ -1,0 +1,8 @@
+package com.teamgreen.apidiff.model;
+
+import lombok.Data;
+
+@Data
+public class GlobalTiraAnnotation {
+    private String key;
+}

--- a/src/main/java/com/teamgreen/apidiff/service/ApiDiffAnalyzerService.java
+++ b/src/main/java/com/teamgreen/apidiff/service/ApiDiffAnalyzerService.java
@@ -67,31 +67,32 @@ public class ApiDiffAnalyzerService {
         JsonNode newAnnotations = newTiraAnnotations.getGlobalTiraAnnotations();
 
         if (oldAnnotations == null) {
-            apiDiffTira.setNewGlobalTiraAnnotation(newAnnotations);
+            newAnnotations.fields().forEachRemaining(entry -> apiDiffTira.getNewGlobalTiraAnnotation().add(mapper.valueToTree(entry)));
             return;
         } else if (newAnnotations == null) {
-            apiDiffTira.setMissingGlobalTiraAnnotation(oldAnnotations);
+            oldAnnotations.fields().forEachRemaining(entry -> apiDiffTira.getMissingGlobalTiraAnnotation().add(mapper.valueToTree(entry)));
             return;
         }
 
         //New global annotations
         newAnnotations.fields().forEachRemaining(entry -> {
                     if (!oldAnnotations.has(entry.getKey()))
-                        apiDiffTira.setNewGlobalTiraAnnotation(mapper.valueToTree(entry));
+                        apiDiffTira.getNewGlobalTiraAnnotation().add(mapper.valueToTree(entry));
                 }
         );
 
         //Missing global annotations
         oldAnnotations.fields().forEachRemaining(entry -> {
                     if (!newAnnotations.has(entry.getKey())) {
-                        apiDiffTira.setMissingGlobalTiraAnnotation(mapper.valueToTree(entry));
+                        apiDiffTira.getMissingGlobalTiraAnnotation().add(mapper.valueToTree(entry));
                     } else {
                         //Check for changes in global annotations which were present in both specifications
                         if (!entry.getValue().equals(newAnnotations.get(entry.getKey()))) {
-                            apiDiffTira.setChangedGlobalTiraAnnotation(
+                            apiDiffTira.getChangedGlobalTiraAnnotation().add(
                                     new ChangedGlobalTiraAnnotation(
-                                            mapper.valueToTree(entry),
-                                            newAnnotations.get(entry.getKey())
+                                            entry.getKey(),
+                                            entry.getValue().get(0),
+                                            newAnnotations.get(entry.getKey()).get(0)
                                     )
                             );
                         }


### PR DESCRIPTION
This merge will sliglty change the way Global Tira Annotation diffs are being represented for easier processing.
Also ApiDiff and ApiDiffTira will now return empty lists instead of null, if the lists are empty.